### PR TITLE
Send templates to cog instance

### DIFF
--- a/lib/relay/announcer.ex
+++ b/lib/relay/announcer.ex
@@ -376,11 +376,9 @@ defmodule Relay.Announcer do
                     :increment -> false
                   end
 
-    configs = Enum.map(List.wrap(configs), &include_template_sources/1)
-
     %{announce: %{relay: creds.id,
                   online: true,
-                  bundles: configs,
+                  bundles: List.wrap(configs),
                   snapshot: is_snapshot,
                   reply_to: topic,
                   announcement_id: id}}
@@ -452,19 +450,4 @@ defmodule Relay.Announcer do
   # loop data invariant predicate
   defp no_in_flight_announcements?(loop_data),
     do: loop_data.in_flight == %{}
-
-  defp include_template_sources(config) do
-    templates = Map.get(config, "templates", [])
-
-    root = Application.get_env(:relay, :bundle_root)
-    bundle_path = Path.join(root, config["bundle"]["name"])
-
-    templates = for template <- templates do
-      %{"path" => relative_path} = template
-      template_path = Path.join(bundle_path, relative_path)
-      Map.put(template, "source", File.read!(template_path))
-    end
-
-    Map.put(config, "templates", templates)
-  end
 end

--- a/lib/relay/bundle/scanner.ex
+++ b/lib/relay/bundle/scanner.ex
@@ -119,7 +119,6 @@ defmodule Relay.Bundle.Scanner do
               {:ok, _} ->
                 BundleFile.close(bf)
                 {:ok, config} = Catalog.bundle_config(bf.name)
-                config = include_template_sources(config)
                 case Announcer.announce(config) do
                   :ok ->
                     {:ok, bf.installed_path}
@@ -225,18 +224,4 @@ defmodule Relay.Bundle.Scanner do
     end
   end
 
-  defp include_template_sources(config) do
-    templates = Map.get(config, "templates", [])
-
-    root = Application.get_env(:relay, :bundle_root)
-    bundle_path = Path.join(root, config["bundle"]["name"])
-
-    templates = for template <- templates do
-      %{"path" => relative_path} = template
-      template_path = Path.join(bundle_path, relative_path)
-      Map.put(template, "source", File.read!(template_path))
-    end
-
-    Map.put(config, "templates", templates)
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Relay.Mixfile do
      #
      # Ditto for Piper (a dependency of spanner and runtime dependency
      # of bundles).
-     {:spanner, git: "git@github.com:operable/spanner", ref: "4b38ada8203bc9fb86bfe963e60040b9d6980b53"},
+     {:spanner, git: "git@github.com:operable/spanner", ref: "73018479972f81a8619085de67e76432b65ae637"},
 
      # Same as Loop uses, and only for test, as a way to get around
      # Mix's annoying habit of starting up the application before

--- a/mix.lock
+++ b/mix.lock
@@ -16,5 +16,5 @@
   "mochiweb": {:git, "git://github.com/emqtt/mochiweb.git", "f1ce26fe373b2a9b52b0b1a5d2306ebb225af7bd", [branch: "master"]},
   "piper": {:git, "git@github.com:operable/piper", "01a5ff07e9d24b712c5fa71736940ac9b69d1ef8", [ref: "01a5ff07e9d24b712c5fa71736940ac9b69d1ef8"]},
   "poison": {:hex, :poison, "1.5.0"},
-  "spanner": {:git, "git@github.com:operable/spanner", "4b38ada8203bc9fb86bfe963e60040b9d6980b53", [ref: "4b38ada8203bc9fb86bfe963e60040b9d6980b53"]},
+  "spanner": {:git, "git@github.com:operable/spanner", "73018479972f81a8619085de67e76432b65ae637", [ref: "73018479972f81a8619085de67e76432b65ae637"]},
   "uuid": {:hex, :uuid, "1.0.1"}}


### PR DESCRIPTION
Template sources are included with their bundles in announce calls. This allows us to store templates in the db of the cog instance for rendering responses from the executor.
