### PR TITLE
Adding spanner config for command config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,4 +17,8 @@ config :relay, pending_bundle_root: Path.join([File.cwd!, "pending"])
 config :relay, triage_bundle_root: Path.join([File.cwd!, "failed"])
 config :relay, bundle_scan_interval_secs: 30
 
+config :spanner, :command_config_root,
+  System.get_env("COG_COMMAND_CONFIG_ROOT")
+
+
 import_config "#{Mix.env}.exs"


### PR DESCRIPTION
This is a change to add the command_config config for Spanner to Relay. This env var will need to be set when installing bundles to a directory where command configs will be stored. 

For example, `~/operable/command_configs` where you will have config.json files for each bundle installed. This data will be used when executing commands within that bundle.

For example, `~/operable/command_configs/github/config.json` may contain credentials for accessing repos.
