### PR TITLE
Add a start script to set the default node name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Relay
+# Relay [![Build status](https://badge.buildkite.com/47fdc4d88997cda24fc0aaaf7f7297e1edd7ad7cc9c277f937.svg)](https://buildkite.com/operable/relay) 
 
-## CI Status
+Run the following to get started:
 
-[![Build status](https://badge.buildkite.com/47fdc4d88997cda24fc0aaaf7f7297e1edd7ad7cc9c277f937.svg)](https://buildkite.com/operable/relay)
-
+```
+mix deps.get
+scripts/start.sh
+```

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+iex --name relay@127.0.0.1 -S mix


### PR DESCRIPTION
Added a `scripts/start.sh`.

Closes https://github.com/operable/cog/issues/105
