### PR TITLE
Validate the template path

### DIFF
--- a/lib/relay/bundle/installer.ex
+++ b/lib/relay/bundle/installer.ex
@@ -147,10 +147,10 @@ defmodule Relay.Bundle.Installer do
           File.close(fd)
           verify_template_paths(bf, config, t, [cmd|accum])
         {:error, _} ->
-          {:error, {:unable_to_open, cmd["template"], template_path}}
+          {:error, {:unable_to_open, cmd["name"], template_path}}
       end
     else
-      {:error, {:missing_file, cmd["template"], template_path}}
+      {:error, {:missing_file, cmd["name"], template_path}}
     end
   end
 


### PR DESCRIPTION
Instead of the template source being in the `config.json` we put the file path to a file containing the template source. We need to make sure that the file exists and that we can open it.

Partial fix for https://github.com/operable/cog/issues/130
