### PR TITLE
Check for 'goon' when Relay starts

### DIFF
--- a/lib/relay.ex
+++ b/lib/relay.ex
@@ -3,13 +3,31 @@ defmodule Relay do
   use Application
   require Logger
 
+  alias Relay.Util.FileFinder
+
   def start(_, _) do
+    goon_check()
     case Relay.TopSupervisor.start_link() do
       {:ok, pid} ->
         {:ok, pid}
       error ->
         Logger.error("Error starting relay: #{inspect error}")
         error
+    end
+  end
+
+  defp goon_check() do
+    f = FileFinder.make(env_var: "$PATH")
+    case FileFinder.find(f, "goon", [:executable]) do
+      nil ->
+        Logger.warn("Failed to detect 'goon' executable via $PATH. Command execution may be unstable.")
+        Logger.info("""
+goon is available from the following sources:
+  Operable's homebrew repo: https://github.com/operable/homebrew-operable
+  Alexei Sholik's GitHub repo: https://github.com/alco/goon
+""")
+      path ->
+        Logger.info("'goon' executable found: #{path}.")
     end
   end
 

--- a/lib/relay/util/file_finder.ex
+++ b/lib/relay/util/file_finder.ex
@@ -1,0 +1,90 @@
+defmodule Relay.Util.FileFinder do
+  require Logger
+  require Bitwise
+
+  @moduledoc """
+  Executes filesystem searches using caller-specified search criteria
+  """
+
+  defstruct dirs: []
+
+  def make([env_var: name]) when is_binary(name) do
+    name = clean_env_var(name)
+    value = System.get_env(name)
+    if value == nil do
+      Logger.warn("Environment variable '#{name}' is not set.")
+      nil
+    else
+      %__MODULE__{dirs: String.split(value, ":")}
+    end
+  end
+  def make([dirs: []]) do
+    Logger.warn("Directory list is empty.")
+    nil
+  end
+  def make([dirs: dirs]) when is_list(dirs) do
+    %__MODULE__{dirs: dirs}
+  end
+
+  def find(%__MODULE__{}=finder, name, opts \\ []) do
+    case do_search(finder.dirs, name) do
+      nil ->
+        nil
+      path ->
+        apply_options(path, opts)
+    end
+  end
+
+  defp apply_options(path, []) do
+    path
+  end
+  defp apply_options(path, [:dir|t]) do
+    if File.dir?(path) do
+      apply_options(path, t)
+    else
+      nil
+    end
+  end
+  defp apply_options(path, [:file|t]) do
+    if File.regular?(path) do
+      apply_options(path, t)
+    else
+      nil
+    end
+  end
+  defp apply_options(path, [:executable|t]) do
+    stat = File.stat!(path)
+    cond do
+      Bitwise.bor(stat.mode, 0o050) == stat.mode ->
+        apply_options(path, t)
+      Bitwise.bor(stat.mode, 0o005) == stat.mode ->
+        apply_options(path, t)
+      true ->
+        nil
+    end
+  end
+
+  defp clean_env_var(<<"$", name::binary>>) do
+    String.upcase(name)
+  end
+  defp clean_env_var(name) do
+    String.upcase(name)
+  end
+
+  defp do_search([], _name) do
+    nil
+  end
+  defp do_search([path|t], name) do
+    candidate = Path.join(path, name)
+    cond do
+      path == name ->
+        path
+      File.exists?(candidate) ->
+        candidate
+      Path.basename(path) == name ->
+        path
+      true ->
+        do_search(t, name)
+    end
+  end
+end

--- a/test/relay/file_finder_test.exs
+++ b/test/relay/file_finder_test.exs
@@ -1,0 +1,29 @@
+defmodule Relay.FileFinderTest do
+
+  alias Relay.Util.FileFinder
+
+  use ExUnit.Case
+
+  test "seed with env var;find directory" do
+    f = FileFinder.make(env_var: "path")
+    assert FileFinder.find(f, "/usr/local/bin", [:dir]) == "/usr/local/bin"
+  end
+
+  test "seed with env var;find file" do
+    f = FileFinder.make(env_var: "$PATH")
+    path = FileFinder.find(f, "ls", [:file, :executable])
+    assert path != nil
+    assert path == "/bin/ls" or path == "/usr/bin/ls"
+  end
+
+  test "seed with dir list;find subdir" do
+    f = FileFinder.make(dirs: ["/usr/local"])
+    assert FileFinder.find(f, "lib", [:dir]) == "/usr/local/lib"
+  end
+
+  test "missing file isn't found" do
+    f = FileFinder.make(env_var: "$PATH")
+    assert FileFinder.find(f, "should_not_exit") == nil
+  end
+
+end


### PR DESCRIPTION
Porcelain, the process mgmt lib we're using to execute commands, offers a number of additional features (sending processes signals, better crash handling, etc) when it's native driver 'goon' is installed. This commit adds a check for goon at startup. If goon isn't found on $PATH a warning is logged along with instructions on obtaining goon.
