### PR TITLE
remove extra shift for value-less options

### DIFF
--- a/scripts/relay
+++ b/scripts/relay
@@ -45,11 +45,9 @@ while [ "$#" -gt 0 ];
 do
   case "$1" in
     --foreground)
-      shift
       FOREGROUND="true"
       ;;
     -fg)
-      shift
       FOREGROUND="true"
       ;;
     --dir)


### PR DESCRIPTION
I fixed this locally but somehow missed committing with the earlier PR. Moving this along since it's so straightforward.
