### PR TITLE
Bump spanner dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,3 @@
-
 Code.load_file(Path.join([__DIR__, "config", "helpers.exs"]))
 
 defmodule Relay.Mixfile do
@@ -44,8 +43,6 @@ defmodule Relay.Mixfile do
 
   defp deps do
     [{:emqttc, github: "operable/emqttc", ref: "dc36f593822f8e01771a7edc780441fdfb2f7b15"},
-     {:poison, "~> 1.5.2"},
-     {:uuid, "~> 1.1.3"},
      {:logger_file_backend, github: "onkel-dirtus/logger_file_backend", ref: "457ce74fc242261328f71a77d75252bf0c74c170"},
 
      # Though we do not explicitly use Spanner in Relay, we provide it
@@ -58,7 +55,9 @@ defmodule Relay.Mixfile do
      #
      # Ditto for Piper (a dependency of spanner and runtime dependency
      # of bundles).
-     {:spanner, git: "git@github.com:operable/spanner", ref: "33af977194f2377048ae41a4e9d180ebc86e4d70"},
+     #
+     # This is also how we get poison and uuid, BTW.
+     {:spanner, git: "git@github.com:operable/spanner", ref: "952dd481ad7f86984254b7c0a8053234fee1a23b"},
 
      # Same as Cog uses, and only for test, as a way to get around
      # Mix's annoying habit of starting up the application before

--- a/mix.lock
+++ b/mix.lock
@@ -18,5 +18,5 @@
   "piper": {:git, "git@github.com:operable/piper", "acfb2150a25004a5ab2a80e7a5bfd418f35ea532", [ref: "acfb2150a25004a5ab2a80e7a5bfd418f35ea532"]},
   "poison": {:hex, :poison, "1.5.2"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
-  "spanner": {:git, "git@github.com:operable/spanner", "33af977194f2377048ae41a4e9d180ebc86e4d70", [ref: "33af977194f2377048ae41a4e9d180ebc86e4d70"]},
+  "spanner": {:git, "git@github.com:operable/spanner", "952dd481ad7f86984254b7c0a8053234fee1a23b", [ref: "952dd481ad7f86984254b7c0a8053234fee1a23b"]},
   "uuid": {:hex, :uuid, "1.1.3"}}


### PR DESCRIPTION
Also, don't lock `poison` and `uuid` dependencies, as we'll inherit what
we need from spanner, carrier, et al.
