### PR TITLE
update relay install to work with updated spanner

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Relay.Mixfile do
      # of bundles).
      #
      # This is also how we get poison and uuid, BTW.
-     {:spanner, github: "operable/spanner", ref: "729a2550e6a7a81e6bd6fcc5a178458cbca91677"},
+     {:spanner, github: "operable/spanner", ref: "9b3413905d8ab29b34bd2b1d951fd3a27e5723ec"},
 
      # For yaml parsing. yaml_elixir is a wrapper around yamerl which is a native erlang lib.
      {:yaml_elixir, "~> 1.0.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Relay.Mixfile do
      # of bundles).
      #
      # This is also how we get poison and uuid, BTW.
-     {:spanner, github: "operable/spanner", ref: "1b4013d3d42e82a72ee7ca01e475c69a7295fe22"},
+     {:spanner, github: "operable/spanner", ref: "74dd8ff2c6112ddd6cc67e057dfaf7e7ba744327"},
 
      # For yaml parsing. yaml_elixir is a wrapper around yamerl which is a native erlang lib.
      {:yaml_elixir, "~> 1.0.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Relay.Mixfile do
      # of bundles).
      #
      # This is also how we get poison and uuid, BTW.
-     {:spanner, github: "operable/spanner", ref: "74dd8ff2c6112ddd6cc67e057dfaf7e7ba744327"},
+     {:spanner, github: "operable/spanner", ref: "729a2550e6a7a81e6bd6fcc5a178458cbca91677"},
 
      # For yaml parsing. yaml_elixir is a wrapper around yamerl which is a native erlang lib.
      {:yaml_elixir, "~> 1.0.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -16,10 +16,10 @@
   "logger_file_backend": {:git, "https://github.com/onkel-dirtus/logger_file_backend.git", "457ce74fc242261328f71a77d75252bf0c74c170", [ref: "457ce74fc242261328f71a77d75252bf0c74c170"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6"},
   "mochiweb": {:git, "git://github.com/emqtt/mochiweb.git", "f1ce26fe373b2a9b52b0b1a5d2306ebb225af7bd", [branch: "master"]},
-  "piper": {:git, "https://github.com/operable/piper.git", "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70", [ref: "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70"]},
+  "piper": {:git, "https://github.com/operable/piper.git", "c0f65733209d985d0a25b9372ba4ecc62ea77f7f", [ref: "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70"]},
   "poison": {:hex, :poison, "1.5.2"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "74dd8ff2c6112ddd6cc67e057dfaf7e7ba744327", [ref: "74dd8ff2c6112ddd6cc67e057dfaf7e7ba744327"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "729a2550e6a7a81e6bd6fcc5a178458cbca91677", [ref: "729a2550e6a7a81e6bd6fcc5a178458cbca91677"]},
   "uuid": {:hex, :uuid, "1.1.3"},
   "yamerl": {:git, "https://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []},
   "yaml_elixir": {:hex, :yaml_elixir, "1.0.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "piper": {:git, "https://github.com/operable/piper.git", "c0f65733209d985d0a25b9372ba4ecc62ea77f7f", [ref: "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70"]},
   "poison": {:hex, :poison, "1.5.2"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "729a2550e6a7a81e6bd6fcc5a178458cbca91677", [ref: "729a2550e6a7a81e6bd6fcc5a178458cbca91677"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "9b3413905d8ab29b34bd2b1d951fd3a27e5723ec", [ref: "9b3413905d8ab29b34bd2b1d951fd3a27e5723ec"]},
   "uuid": {:hex, :uuid, "1.1.3"},
   "yamerl": {:git, "https://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []},
   "yaml_elixir": {:hex, :yaml_elixir, "1.0.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "piper": {:git, "https://github.com/operable/piper.git", "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70", [ref: "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70"]},
   "poison": {:hex, :poison, "1.5.2"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "1b4013d3d42e82a72ee7ca01e475c69a7295fe22", [ref: "1b4013d3d42e82a72ee7ca01e475c69a7295fe22"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "74dd8ff2c6112ddd6cc67e057dfaf7e7ba744327", [ref: "74dd8ff2c6112ddd6cc67e057dfaf7e7ba744327"]},
   "uuid": {:hex, :uuid, "1.1.3"},
   "yamerl": {:git, "https://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []},
   "yaml_elixir": {:hex, :yaml_elixir, "1.0.0"}}


### PR DESCRIPTION
This updates the relay bundle installer to user the new Spanner.Config bits. It also adds some verification for rules and restructures some of the validation code.

resolves operable/cog#273