### PR TITLE
Bump spanner to pick up pipeline STDIN

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Relay.Mixfile do
      # of bundles).
      #
      # This is also how we get poison and uuid, BTW.
-     {:spanner, github: "operable/spanner", ref: "895a9966cab02637cace9bdb245bb5308b3fbf79"},
+     {:spanner, github: "operable/spanner", ref: "4c0a59daddd51b93abc1b891cfc0876f296e8c1b"},
 
      # For yaml parsing. yaml_elixir is a wrapper around yamerl which is a native erlang lib.
      {:yaml_elixir, "~> 1.0.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "piper": {:git, "https://github.com/operable/piper.git", "c0f65733209d985d0a25b9372ba4ecc62ea77f7f", [ref: "1eb0069bbdc17fdf0312f9f7b1be6224f16e3e70"]},
   "poison": {:hex, :poison, "1.5.2"},
   "porcelain": {:hex, :porcelain, "2.0.1"},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "ad6661bac1a80c8b36d2cd90ec524585f5ae3f1e", [ref: "895a9966cab02637cace9bdb245bb5308b3fbf79"]},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "4c0a59daddd51b93abc1b891cfc0876f296e8c1b", [ref: "4c0a59daddd51b93abc1b891cfc0876f296e8c1b"]},
   "uuid": {:hex, :uuid, "1.1.3"},
   "yamerl": {:git, "https://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []},
   "yaml_elixir": {:hex, :yaml_elixir, "1.0.0"}}


### PR DESCRIPTION
This brings in https://github.com/operable/spanner/pull/53 to send pipeline context to the next stage in the pipeline via STDIN.